### PR TITLE
Update logging to use MASK_LOG_IMU for IMU data only

### DIFF
--- a/ArduPlane/ArduPlane.cpp
+++ b/ArduPlane/ArduPlane.cpp
@@ -306,7 +306,7 @@ void Plane::update_logging25(void)
     if (should_log(MASK_LOG_RC))
         Log_Write_RC();
 
-    if (should_log(MASK_LOG_IMU))
+    if (should_log(MASK_LOG_SENSORS))
         AP::ins().Write_Vibration();
 }
 #endif  // HAL_LOGGING_ENABLED

--- a/ArduPlane/Parameters.cpp
+++ b/ArduPlane/Parameters.cpp
@@ -645,8 +645,8 @@ const AP_Param::Info Plane::var_info[] = {
 
     // @Param: LOG_BITMASK
     // @DisplayName: Log bitmask
-    // @Description: Bitmap of what on-board log types to enable. This value is made up of the sum of each of the log types you want to be saved. It is usually best just to enable all basic log types by setting this to 65535.
-    // @Bitmask: 0:Fast Attitude,1:Medium Attitude,2:GPS,3:Performance,4:Control Tuning,5:Navigation Tuning,7:IMU,8:Mission Commands,9:Battery Monitor,10:Compass,11:TECS,12:Camera,13:RC Input-Output,14:Rangefinder,19:Raw IMU,20:Fullrate Attitude,21:Video Stabilization,22:Fullrate Notch
+    // @Description: Bitmap of what on-board log types to enable. This value is made up of the sum of each of the log types you want to be saved. It is usually best just to enable all basic log types by setting this to 65535. Sensors includes airpseed, barometer and vibrations.
+    // @Bitmask: 0:Fast Attitude,1:Medium Attitude,2:GPS,3:Performance,4:Control Tuning,5:Navigation Tuning,7:IMU,8:Mission Commands,9:Battery Monitor,10:Compass,11:TECS,12:Camera,13:RC Input-Output,14:Rangefinder,19:Raw IMU,20:Fullrate Attitude,21:Video Stabilization,22:Fullrate Notch,23:Sensors
     // @User: Advanced
     GSCALAR(log_bitmask,            "LOG_BITMASK",    DEFAULT_LOG_BITMASK),
 

--- a/ArduPlane/defines.h
+++ b/ArduPlane/defines.h
@@ -126,6 +126,7 @@ enum log_messages {
 #define MASK_LOG_ATTITUDE_FULLRATE      (1U<<20)
 #define MASK_LOG_VIDEO_STABILISATION    (1UL<<21)
 #define MASK_LOG_NOTCH_FULLRATE         (1UL<<22)
+#define MASK_LOG_SENSORS                (1UL<<23)
 
 enum {
     CRASH_DETECT_ACTION_BITMASK_DISABLED = 0,

--- a/ArduPlane/system.cpp
+++ b/ArduPlane/system.cpp
@@ -67,7 +67,7 @@ void Plane::init_ardupilot()
 
 #if AP_AIRSPEED_ENABLED
     airspeed.set_fixedwing_parameters(&aparm);
-    airspeed.set_log_bit(MASK_LOG_IMU);
+    airspeed.set_log_bit(MASK_LOG_SENSORS);
 #endif
 
     // GPS Initialization
@@ -436,7 +436,7 @@ void Plane::startup_INS(void)
 
     // read Baro pressure at ground
     //-----------------------------
-    barometer.set_log_baro_bit(MASK_LOG_IMU);
+    barometer.set_log_baro_bit(MASK_LOG_SENSORS);
     barometer.calibrate();
 }
 

--- a/ArduPlane/version.h
+++ b/ArduPlane/version.h
@@ -6,7 +6,7 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "ArduPlane V4.6.3"
+#define THISFIRMWARE "MarblePlane V4.6.3.1"
 
 // the following line is parsed by the autotest scripts
 #define FIRMWARE_VERSION 4,6,3,FIRMWARE_VERSION_TYPE_OFFICIAL


### PR DESCRIPTION
<img width="1594" height="211" alt="image" src="https://github.com/user-attachments/assets/86bc207b-7740-410c-9889-dca830d2399c" />

With IMU and SENSORS unchecked:
<img width="1194" height="1316" alt="image" src="https://github.com/user-attachments/assets/2f34e1b9-4b0e-4a6e-8d69-0d64cd76b13f" />

WIth IMU unchecked and SENSORS checked:
<img width="1181" height="1324" alt="image" src="https://github.com/user-attachments/assets/2f7f60c6-60b1-42b7-8418-116acd8f9225" />

With IMU and SENSORS checked:
<img width="1188" height="1294" alt="image" src="https://github.com/user-attachments/assets/4641b11e-2394-4fac-bfd6-1adb4d125ab8" />


Note: Need to update mission planner param def xmls for log bitmask to properly update (`python Tools/autotest/param_metadata/param_parse.py --vehicle ArduPlane --format xml`), otherwise just add `8388608` to the bitmask value.